### PR TITLE
Corrected synchronisation of CSS3 and JQuery animations

### DIFF
--- a/dom/www/js/ff.js
+++ b/dom/www/js/ff.js
@@ -537,7 +537,7 @@ $(function () {
     t = parseInt($(this).val());
     $('#animation-duration').text(t);
     $('#damage').css({
-      animationDuration: t + 'ms'
+      animationDuration: (1.5 * t | 0) + 'ms'
     });
     outcomeDelay = 1.5 * t;
   });


### PR DESCRIPTION
The CSS3 take damage animation was previously finishing sooner than the JQuery callbacks to update the stamina numbers.