### PR TITLE
Prevented revival during outcome dialogue

### DIFF
--- a/dom/www/js/ff.js
+++ b/dom/www/js/ff.js
@@ -139,6 +139,9 @@ $(function () {
           $(this).removeClass('hidden');
         });
 
+        // Disable number inputs while the outcome dialogue is shown
+        $('input[type="number"]').attr('readonly', true);
+
         // Apply styles for dead target
         $('#fight').removeClass(target + '-critical').addClass(target + '-dead');
       } else {
@@ -481,6 +484,9 @@ $(function () {
   function reset() {
     // Hide the outcome dialogue when F is pressed
     $('#outcome-dialogue').fadeOut(t).addClass('hidden');
+
+    // Re-enable number inputs
+    $('input[type="number"]').attr('readonly', false);
 
     // Show the help text once faded
     setTimeout(function () {


### PR DESCRIPTION
Changing the stamina of a dead character when the outcome dialogue was shown previously caused a weird state to occur where the outcome dialogue would still be shown but the game could be continued without reset being called.

The number inputs are now made readonly while the outcome dialogue is shown to prevent this.