### PR TITLE
Adjusted CSS shadows

### DIFF
--- a/dom/www/css/ff.css
+++ b/dom/www/css/ff.css
@@ -40,14 +40,15 @@ table td {
   column-width: 286px;
 }
 
-table td:first-child {
-  background-color: #FEB;
-  box-shadow: 0px 1px 2px -1px #777;
-}
-
+table td:first-child,
 table td:last-child {
   background-color: #FEB;
-  box-shadow: 0px 1px 2px -1px #777;
+  box-shadow: 0px 2px 1px -1px #777;
+}
+
+table tr:last-child>td:first-child,
+table tr:last-child>td:last-child {
+  box-shadow: 0px 1px 1px -1px #777;
 }
 
 #fight.hero-critical table td:first-child,


### PR DESCRIPTION
Box shadows previously caused an odd looking overlap when zoomed out or on high dpi screens with UI scaling, which is now adjusted for.